### PR TITLE
Add CSV universe support with weekly options filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ automatic caching so that you only download each symbol once. Key options:
 - `--cache-dir` and `--force-refresh` to manage on-disk caching of daily bars.
 - `--prefetch` with `--max-workers` to download histories in parallel when
   API limits allow.
+- `--universe-csv` to load the point-in-time universe from a CSV file (useful in
+  notebook environments where a database connection is unavailable).
 - `--output-dir` to control where the performance chart and monthly returns
   report are saved. Use `--no-show-plot` when running in a headless
   environment.


### PR DESCRIPTION
## Summary
- allow the backtest to consume a point-in-time universe from a CSV file via a new `--universe-csv` option
- normalize universe loading for both backtest and production scripts and enforce the weekly options filter
- document the CSV workflow in the project README

## Testing
- python -m compileall mtum-backtest-public.py mtum-prod-public.py

------
https://chatgpt.com/codex/tasks/task_e_68e068f47d1c832fbaa98d527cc6e3e8