### PR TITLE
Surface rebalance deciles in production script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The strategy is based on a core concept in quantitative finance: securities that
   - Ranks tickers monthly into deciles.
   - Rebalances monthly based on updated scores.
   - Outputs long and short baskets ready for trading or analysis.
+  - Saves the current rebalance selections to `rebalance_outputs/rebalance_<YYYY-MM-DD>.csv`
+    (relative to the production script) so operators can review the long/short
+    baskets without rerunning the job.
 
 ## 🚀 Faster Backtests
 

--- a/mtum-prod-public.py
+++ b/mtum-prod-public.py
@@ -364,3 +364,38 @@ full_period_ticker_data = pd.concat(monthly_ticker_list)
 top_decile = full_period_ticker_data.sort_values(by="mom_score", ascending = False).head(10)
 bot_decile = full_period_ticker_data.sort_values(by="mom_score", ascending = True).head(10)
 
+display_columns = [
+    "ticker",
+    "mom_score",
+    "beta",
+    "sharpe",
+    "12-1_return",
+    "avg_monthly_return",
+    "forward_returns",
+]
+
+print("\nTop Decile Momentum Basket (long candidates):")
+top_display_columns = [col for col in display_columns if col in top_decile.columns]
+print(top_decile[top_display_columns].to_string(index=False))
+
+print("\nBottom Decile Momentum Basket (short candidates):")
+bot_display_columns = [col for col in display_columns if col in bot_decile.columns]
+print(bot_decile[bot_display_columns].to_string(index=False))
+
+rebalance_output_dir = Path(__file__).resolve().parent / "rebalance_outputs"
+rebalance_output_dir.mkdir(exist_ok=True)
+
+rebalance_output_path = rebalance_output_dir / f"rebalance_{month}.csv"
+
+rebalance_export = pd.concat(
+    [
+        top_decile.assign(decile="top"),
+        bot_decile.assign(decile="bottom"),
+    ],
+    ignore_index=True,
+)
+
+rebalance_export.to_csv(rebalance_output_path, index=False)
+
+print(f"\nRebalance baskets saved to {rebalance_output_path}")
+


### PR DESCRIPTION
## Summary
- print the top and bottom momentum decile tables so the rebalance basket is visible during prod runs
- export the current baskets to a dated CSV in `rebalance_outputs/` for downstream workflows
- document the new CSV output location in the README for discoverability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07aaa5e6c832f8e1f3fd5e2e46639