### PR TITLE
Use trading-day anchors and enforce API key configuration

### DIFF
--- a/mtum-prod-public.py
+++ b/mtum-prod-public.py
@@ -19,6 +19,7 @@ import mysql.connector
 from typing import List
 
 from datetime import datetime, timedelta
+from pandas.tseries.offsets import BDay
 from pandas_market_calendars import get_calendar
 
 
@@ -87,13 +88,11 @@ _load_local_env_file()
 ARGS = _parse_args()
 
 DEFAULT_POLYGON_KEY = "KkfCQ7fsZnx0yK4bhX9fD81QplTh0Pf3"
-polygon_api_key = ARGS.polygon_api_key or os.getenv("POLYGON_API_KEY") or DEFAULT_POLYGON_KEY
+polygon_api_key = ARGS.polygon_api_key or os.getenv("POLYGON_API_KEY")
 
-if polygon_api_key == DEFAULT_POLYGON_KEY:
-    print(
-        "Warning: POLYGON_API_KEY not set; using the placeholder key from the "
-        "repository. Set your own API key via the POLYGON_API_KEY environment "
-        "variable before running in production."
+if not polygon_api_key or polygon_api_key == DEFAULT_POLYGON_KEY:
+    raise RuntimeError(
+        "POLYGON_API_KEY not configured. Provide a valid key via --polygon-api-key or the POLYGON_API_KEY environment variable."
     )
 
 database_url = ARGS.database_url or os.getenv("MTUM_DATABASE_URL")
@@ -180,11 +179,11 @@ start_of_the_months["str_date"] = start_of_the_months["date"].dt.strftime("%Y-%m
 months = start_of_the_months["str_date"].values
 month = months[-1]
 
-start_date = (pd.to_datetime(month) - timedelta(days = 365+60)).strftime("%Y-%m-%d")
+start_date = (pd.to_datetime(month) - BDay(252 + 42)).strftime("%Y-%m-%d")
 end_date = month
 
-last_month_date = (pd.to_datetime(month) - timedelta(days = 30)).strftime("%Y-%m-%d")
-next_month_date = (pd.to_datetime(month) + timedelta(days = 30)).strftime("%Y-%m-%d")
+last_month_date = (pd.to_datetime(month) - BDay(21)).strftime("%Y-%m-%d")
+next_month_date = (pd.to_datetime(month) + BDay(21)).strftime("%Y-%m-%d")
 
 # =============================================================================
 # Base Point-in-Time Universe + Benchmark Generation

--- a/point-in-time-options.py
+++ b/point-in-time-options.py
@@ -5,6 +5,8 @@ Created in 2025
 @author: Quant Galore
 """
 
+import os
+
 import pandas as pd
 import numpy as np
 import requests
@@ -14,7 +16,12 @@ import mysql.connector
 from datetime import datetime, timedelta
 from pandas_market_calendars import get_calendar
 
-polygon_api_key = "KkfCQ7fsZnx0yK4bhX9fD81QplTh0Pf3"
+DEFAULT_POLYGON_KEY = "KkfCQ7fsZnx0yK4bhX9fD81QplTh0Pf3"
+polygon_api_key = os.getenv("POLYGON_API_KEY")
+if not polygon_api_key or polygon_api_key == DEFAULT_POLYGON_KEY:
+    raise RuntimeError(
+        "POLYGON_API_KEY not configured. Set the environment variable before running point-in-time options extraction."
+    )
 
 engine = sqlalchemy.create_engine('mysql+mysqlconnector://user:pass@localhost:3306/my_database')
 


### PR DESCRIPTION
## Summary
- align the backtest feature anchor with trading-day offsets, add turnover-aware costs, and compute compounded NAV series for reporting
- update the production script to mirror the trading-day windows and require explicit Polygon API credentials
- require configured Polygon API keys for the point-in-time options universe loader

## Testing
- python -m compileall mtum-backtest-public.py mtum-prod-public.py point-in-time-options.py

------
https://chatgpt.com/codex/tasks/task_e_68e08a4c0664832fa0deb343c133b9b6