### PR TITLE
Load API credentials from Colab user secrets

### DIFF
--- a/mtum-backtest-public.py
+++ b/mtum-backtest-public.py
@@ -21,6 +21,34 @@ from pandas_market_calendars import get_calendar
 from data_providers import AlpacaBarsClient, PolygonAggsClient
 
 
+def _load_colab_user_secrets() -> None:
+    """Populate environment variables from Colab user secrets when available."""
+
+    try:
+        from google.colab import userdata  # type: ignore
+    except Exception:
+        return
+
+    secret_names = {
+        "POLYGON_API_KEY": "POLYGON_API_KEY",
+        "ALPACA_API_KEY": "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY": "ALPACA_SECRET_KEY",
+    }
+
+    for env_name, secret_name in secret_names.items():
+        if os.getenv(env_name):
+            continue
+        try:
+            value = userdata.get(secret_name)
+        except Exception:
+            continue
+        if value:
+            os.environ[env_name] = value
+
+
+_load_colab_user_secrets()
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the time-series momentum backtest")
     parser.add_argument("--provider", choices=["polygon", "alpaca"], default="polygon", help="Historical data provider")

--- a/mtum-prod-public.py
+++ b/mtum-prod-public.py
@@ -82,8 +82,33 @@ def _load_local_env_file():
         if key and key not in os.environ:
             os.environ[key] = value
 
+def _load_colab_user_secrets() -> None:
+    """Populate environment variables from Colab user secrets when available."""
+
+    try:
+        from google.colab import userdata  # type: ignore
+    except Exception:
+        return
+
+    secret_names = {
+        "POLYGON_API_KEY": "POLYGON_API_KEY",
+        "ALPACA_API_KEY": "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY": "ALPACA_SECRET_KEY",
+    }
+
+    for env_name, secret_name in secret_names.items():
+        if os.getenv(env_name):
+            continue
+        try:
+            value = userdata.get(secret_name)
+        except Exception:
+            continue
+        if value:
+            os.environ[env_name] = value
+
 
 _load_local_env_file()
+_load_colab_user_secrets()
 
 ARGS = _parse_args()
 

--- a/point-in-time-options.py
+++ b/point-in-time-options.py
@@ -16,6 +16,21 @@ import mysql.connector
 from datetime import datetime, timedelta
 from pandas_market_calendars import get_calendar
 
+def _load_colab_user_secrets() -> None:
+    """Populate environment variables from Colab user secrets when available."""
+
+    try:
+        from google.colab import userdata  # type: ignore
+    except Exception:
+        return
+
+    polygon_key = userdata.get("POLYGON_API_KEY") if not os.getenv("POLYGON_API_KEY") else None
+    if polygon_key:
+        os.environ["POLYGON_API_KEY"] = polygon_key
+
+
+_load_colab_user_secrets()
+
 DEFAULT_POLYGON_KEY = "KkfCQ7fsZnx0yK4bhX9fD81QplTh0Pf3"
 polygon_api_key = os.getenv("POLYGON_API_KEY")
 if not polygon_api_key or polygon_api_key == DEFAULT_POLYGON_KEY:


### PR DESCRIPTION
## Summary
- load Polygon and Alpaca credentials from Google Colab user secrets when available
- ensure the point-in-time options script also fetches the Polygon key from Colab secrets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e08d1e9a90832f93e9ead2edd7239d